### PR TITLE
Add state-of-the-art fallback modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ XtrapNet allows you to control how the model reacts to out-of-distribution (OOD)
 | error           | Raises an error when encountering OOD data |
 | highest_confidence | Selects the lowest-variance prediction |
 | backup          | Uses a secondary model when uncertainty is high |
+| deep_ensemble   | Averages predictions from multiple expert models |
+| llm_assist      | Queries an LLM for a fallback prediction |
 
 
 ## Visualizing Extrapolation Behavior

--- a/controller.py
+++ b/controller.py
@@ -1,14 +1,22 @@
+import os
 import torch
 import numpy as np
 from scipy.spatial import KDTree
 
+try:
+    import openai
+except Exception:  # pragma: no cover - openai is optional
+    openai = None
+
 class XtrapController:
-    def __init__(self, trained_model, train_features, train_labels, mode='warn', backup_model=None):
+    def __init__(self, trained_model, train_features, train_labels, mode='warn',
+                 backup_model=None, ensemble_models=None):
         self.model = trained_model
         self.backup_model = backup_model
         self.mode = mode
         self.train_features = train_features
         self.train_labels = train_labels
+        self.ensemble_models = ensemble_models or []
 
         with torch.no_grad():
             preds = self.model.predict(self.train_features)
@@ -49,6 +57,30 @@ class XtrapController:
                         res = self.backup_model.predict(row.reshape(1, -1))[0][0]
                     else:
                         raise ValueError("Backup model not provided!")
+                elif self.mode == 'deep_ensemble':
+                    if not self.ensemble_models:
+                        raise ValueError("Ensemble models not provided!")
+                    preds = [m.predict(row.reshape(1, -1))[0][0] for m in self.ensemble_models]
+                    res = float(np.mean(preds))
+                elif self.mode == 'llm_assist':
+                    if openai is None:
+                        raise ImportError("openai package is required for llm_assist mode")
+                    if not os.getenv("OPENAI_API_KEY"):
+                        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+                    prompt = (
+                        f"Given the features {row.tolist()}, predict the target value "
+                        "for our regression task. Respond with only the number."
+                    )
+                    completion = openai.Completion.create(
+                        model="text-davinci-003",
+                        prompt=prompt,
+                        max_tokens=8,
+                        temperature=0.0,
+                    )
+                    try:
+                        res = float(completion.choices[0].text.strip().split()[0])
+                    except Exception:
+                        res = self.model.predict(row.reshape(1, -1))[0][0]
                 else:
                     res = self.model.predict(row.reshape(1, -1))[0][0]
             else:

--- a/local_test.py
+++ b/local_test.py
@@ -43,11 +43,24 @@ for i, p in enumerate(test_points):
     print(f"Input: {p} → Prediction: {predictions[i]:.4f}")
 
 # Test different fallback strategies
-modes = ['clip', 'zero', 'nearest_data', 'symmetry', 'highest_confidence', 'backup']
+modes = ['clip', 'zero', 'nearest_data', 'symmetry', 'highest_confidence', 'backup', 'deep_ensemble']
+
+ensemble = [net, XtrapNet(input_dim=2)]
+trainer2 = XtrapTrainer(ensemble[1], num_epochs=50)
+trainer2.train(labels, features)
 
 for mode in modes:
     print(f"\nTesting mode: {mode}")
-    xtrap_ctrl = XtrapController(trained_model=net, train_features=features, train_labels=labels, mode=mode)
+    if mode == 'deep_ensemble':
+        xtrap_ctrl = XtrapController(
+            trained_model=net,
+            train_features=features,
+            train_labels=labels,
+            mode=mode,
+            ensemble_models=ensemble,
+        )
+    else:
+        xtrap_ctrl = XtrapController(trained_model=net, train_features=features, train_labels=labels, mode=mode)
     predictions = xtrap_ctrl.predict(test_points)
     for i, p in enumerate(test_points):
         print(f"Mode: {mode} | Input: {p} → Prediction: {predictions[i]:.4f}")

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ setup(
     name='xtrapnet',
     version='0.1.0',
     packages=find_packages(),
-    install_requires=['torch', 'numpy', 'scipy'],
-    author='cyruskurd'
+    install_requires=['torch', 'numpy', 'scipy', 'openai'],
+    author='cyruskurd',
     author_email='cyrus.kurd@columbia.edu',
     description='A robust package for extrapolation control in neural networks',
     url='https://github.com/YourUser/xtrapnet',


### PR DESCRIPTION
## Summary
- add optional OpenAI integration and deep ensemble fallback modes
- document new fallback modes in README
- support ensemble models and optional LLM assisted predictions in `XtrapController`
- update example test script for new modes
- add missing comma and dependency to setup.py

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6840bcf527fc8323bdfb2ce1c7c3ba70